### PR TITLE
Order plugins consistently run to run 

### DIFF
--- a/src/rocker/cli.py
+++ b/src/rocker/cli.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+from collections import OrderedDict
 import os
 import sys
 
@@ -130,11 +131,16 @@ def main():
     parser.add_argument('--pull', action='store_true')
     parser.add_argument('--network', choices=['bridge', 'host', 'overlay', 'none'])
 
-    plugins = {
+    unordered_plugins = {
     entry_point.name: entry_point.load()
     for entry_point
     in pkg_resources.iter_entry_points('rocker.extensions')
     }
+    # Order plugins by extension point name for consistent ordering below
+    plugin_names = list(unordered_plugins.keys())
+    plugin_names.sort()
+    plugins = OrderedDict([(k, unordered_plugins[k]) for k in plugin_names])
+
     print("Plugins found: %s" % [p.get_name() for p in plugins.values()])
     for p in plugins.values():
         p.register_arguments(parser)


### PR DESCRIPTION
The order plugins are invoked is random. This orders the plugins by extension name.

Without this PR the same options could result in different tag names.
```
$ docker images
REPOSITORY          TAG                                                        IMAGE ID            CREATED             SIZE
rocker_osrf/ros     kinetic-desktop-full_oyr_colcon_oyr_spacenav_nvidia        a5aadf988676        28 minutes ago      3.66GB
rocker_osrf/ros     kinetic-desktop-full_oyr_colcon_nvidia_oyr_spacenav        c068170f4061        30 minutes ago      3.66GB
rocker_osrf/ros     kinetic-desktop-full_oyr_spacenav_oyr_colcon_nvidia        d230ed100b2a        31 minutes ago      3.66GB
```